### PR TITLE
ref #1: Use newer FPM proxy configuration to avoid PHP script names w…

### DIFF
--- a/library/httpd/2.4-pagespeed/config/sites-enabled/vhost.conf
+++ b/library/httpd/2.4-pagespeed/config/sites-enabled/vhost.conf
@@ -6,6 +6,8 @@
  CustomLog /proc/self/fd/1 combined
  TimeOut  650
  KeepAliveTimeout 650
- ProxyPassMatch "^/(.*\.php(/.*)?)$" "fcgi://php:9000/usr/local/apache2/htdocs/customer/web/$1" timeout=650 connectiontimeout=650
+ <FilesMatch \.php$>
+   SetHandler proxy:fcgi://php:9000
+ </FilesMatch>
  DirectoryIndex /index.php index.php
 </VirtualHost>

--- a/library/httpd/2.4/config/sites-enabled/vhost.conf
+++ b/library/httpd/2.4/config/sites-enabled/vhost.conf
@@ -6,6 +6,8 @@
  CustomLog /proc/self/fd/1 combined
  TimeOut  650
  KeepAliveTimeout 650
- ProxyPassMatch "^/(.*\.php(/.*)?)$" "fcgi://php:9000/usr/local/apache2/htdocs/customer/web/$1" timeout=650 connectiontimeout=650
+ <FilesMatch \.php$>
+   SetHandler proxy:fcgi://php:9000
+ </FilesMatch>
  DirectoryIndex /index.php index.php
 </VirtualHost>


### PR DESCRIPTION
…ith trailing slash in some environments