### PR TITLE
Add AuthMerging directive to basic authentication

### DIFF
--- a/library/httpd/2.4-waf/config/patchpanel.sh
+++ b/library/httpd/2.4-waf/config/patchpanel.sh
@@ -66,6 +66,7 @@ if [ ! -f ${LOCKFILE} ]; then
 	  fi
 
 	    echo "<RequireAny>
+	    AuthMerging And
 	    AuthName \"protected\"
 	    AuthUserFile /usr/local/apache2/conf/htuser
 	    AuthType Basic


### PR DESCRIPTION
By default, authentication blocks are not merged with one-another with
the more specific block overriding the less specific one. In this
context this resulted in the .htaccess blocking in apache2 being
overriden by the basic authentication added by patchpanel making the
.htaccess files accessible on sites that have basic auth enabled.

Adding `AuthMerging And` results in the more specific block taking
the less-specific block into account.

See also: https://httpd.apache.org/docs/trunk/en/mod/mod_authz_core.html#authmerging